### PR TITLE
Create a facility to load the whole CS curriculum specified in word or in pdf

### DIFF
--- a/backend/src/main/java/com/example/auditor/controller/curriculum/CurriculumController.java
+++ b/backend/src/main/java/com/example/auditor/controller/curriculum/CurriculumController.java
@@ -48,6 +48,12 @@ public class CurriculumController {
         return parseService.uploadCurriculum(id, file);
     }
 
+    @PostMapping(value = "/{id}/plan", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public Curriculum addCurriculumPlan(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+
+        return parseService.addCurriculumPlan(id, file);
+    }
+
     @PostMapping("/{id}/manual")
     public Curriculum uploadManualRequirements(
             @PathVariable Long id,

--- a/backend/src/main/java/com/example/auditor/domain/curriculum/Requirement.java
+++ b/backend/src/main/java/com/example/auditor/domain/curriculum/Requirement.java
@@ -24,7 +24,7 @@ public class Requirement {
     private String patterns;
     private String antipatterns;
     private Integer credit;
-
+    private Integer semester;
     private String type;
 
 }

--- a/backend/src/main/java/com/example/auditor/domain/report/ReportRequirement.java
+++ b/backend/src/main/java/com/example/auditor/domain/report/ReportRequirement.java
@@ -24,6 +24,7 @@ public class ReportRequirement {
     private String patterns;
     private String antipatterns;
     private Integer credit;
+    private Integer semester;
     private String type;
 
 
@@ -35,6 +36,7 @@ public class ReportRequirement {
                 .antipatterns(requirement.getAntipatterns())
                 .credit(requirement.getCredit())
                 .type(requirement.getType())
+                .semester(requirement.getSemester())
                 .build();
     }
 

--- a/backend/src/main/java/com/example/auditor/dto/RequirementDto.java
+++ b/backend/src/main/java/com/example/auditor/dto/RequirementDto.java
@@ -14,6 +14,7 @@ public class RequirementDto {
     private Integer credit;
     private String patterns;
     private String antipatterns;
+    private Integer semester;
 
     public String getPatterns() {
 

--- a/frontend/src/views/Curriculum/Index.vue
+++ b/frontend/src/views/Curriculum/Index.vue
@@ -5,6 +5,13 @@
         <v-row justify="end">
             <v-col cols="1">
                 <v-btn
+                        @click="addFile = true"
+                >
+                    Add plan
+                </v-btn>
+            </v-col>
+            <v-col cols="1">
+                <v-btn
                         @click="$router.push({ name: 'Curriculum-edit', params: {id: curriculum.id} })"
                         color="success"
                 >
@@ -29,6 +36,66 @@
             v-bind:curriculum="curriculum"
           />
         </base-material-card>
+        <v-dialog
+            v-model="addFile"
+            max-width="600">
+            <v-card>
+                <v-card-title class="display-2">
+                    Upload Plan
+                    <v-spacer />
+
+                    <v-icon
+                        aria-label="Close"
+                        @click="addFile = false"
+                    >
+                        mdi-close
+                    </v-icon>
+                </v-card-title>
+
+                <v-card-text>
+                    <v-file-input
+                        v-model="files"
+                        show-size
+                        counter
+                        placeholder="Select file"
+                        prepend-icon="mdi-paperclip"
+                        outlined
+                        accept=".docx"
+                    >
+                        <template v-slot:selection="{ index, text }">
+                            <v-chip
+                                v-if="index < 2"
+                                dark
+                                label
+                                small
+                            >
+                                {{ text }}
+                            </v-chip>
+                        </template>
+                    </v-file-input>
+                </v-card-text>
+
+                <v-divider></v-divider>
+
+                <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn
+                        color="primary"
+                        text
+                        @click="submitFile()"
+                    >
+                        Ok
+                    </v-btn>
+                    <v-btn
+                        color="primary"
+                        text
+                        @click="addFile = false"
+                    >
+                        Close
+                    </v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
     </v-container>
 </template>
 
@@ -38,7 +105,10 @@ import {download, get, post} from '../../helpers/api'
     export default {
       data () {
         return {
-          curriculum: ''
+          curriculum: '',
+          curriculumId: '',
+          addFile: false,
+          files: []
         }
       },
 
@@ -47,6 +117,29 @@ import {download, get, post} from '../../helpers/api'
       },
 
       methods: {
+
+        submitFile() {
+          let _this = this;
+          let formData = new FormData();
+          formData.append('file', this.files);
+          _this.curriculumId = this.$route.params.id;
+
+          post(_this, '/curriculum/'+_this.curriculumId + '/plan', formData, response=> {
+            _this.curriculum = response.data;
+            _this.stage = 2;
+            _this.tab = 2;
+            _this.addFile = false;
+            _this.$store.dispatch('setSnackbar', {text: "Curriculum successfully filled"})
+          }, error=>{
+            _this.$store.dispatch('setSnackbar', {
+              text: error,
+              color: "error"
+            })
+          }, {
+            'Content-Type': 'multipart/form-data'
+          });
+
+        },
 
         getCurriculum(){
           let _this = this;

--- a/frontend/src/views/components/curriculum/Requirement.vue
+++ b/frontend/src/views/components/curriculum/Requirement.vue
@@ -5,6 +5,7 @@
     <td>{{requirement.credit}}</td>
     <td>{{requirement.patterns}}</td>
     <td>{{requirement.antipatterns}}</td>
+    <td>{{requirement.semester}}</td>
   </tr>
 </template>
 

--- a/frontend/src/views/components/curriculum/RequirementsTable.vue
+++ b/frontend/src/views/components/curriculum/RequirementsTable.vue
@@ -22,6 +22,9 @@
           <th class="primary--text display-1">
             Antipatterns
           </th>
+          <th class="primary--text display-1">
+            Semester
+          </th>
         </tr>
       </thead>
 


### PR DESCRIPTION
Added button to curriculum index page (http://localhost:8081/#/curriculum/253) to upload "CS UG Courses - Aug 2021" file to a specific curriculum. I do not store courses from word doc in the database. Instead, I added semester integer field to requirement class, parse the word document, and assign semester numbers to those requirements from the existing curriculum whose names match. Since some course names are written differently in curriculum and word document, only some courses are assigned semester numbers. There are mistakes. For example, all four technical electives are assigned semester number 7, but I don't know how to deal with it for now.